### PR TITLE
Enable optional thumbnail theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Setting the color style (default is `edit-xcode`, see [all available themes](htt
 
     defaults write org.n8gray.QLColorCode hlTheme ide-xcode
     
+Setting the thumbnail color style (deactivated by default):
+
+    defaults write org.n8gray.QLColorCode hlThumbTheme ide-xcode
+
 Setting the maximum size (in bytes, deactivated by default) for previewed files:
 
     defaults write org.n8gray.QLColorCode maxFileSize 1000000

--- a/src/Common.m
+++ b/src/Common.m
@@ -77,15 +77,23 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
 #endif
                                    @"10", @"fontSizePoints",
                                    @"Menlo", @"font",
-                                   @"edit-xcode", @"hlTheme", 
+                                   @"edit-xcode", @"hlTheme",
 //                                   @"-lz -j 3 -t 4 --kw-case=capitalize ", @"extraHLFlags", 
                                    @"-t 4 --kw-case=capitalize ", @"extraHLFlags", 
                                    @"/opt/local/bin/highlight", @"pathHL",
                                    @"", @"maxFileSize",
                                    @"UTF-8", @"textEncoding", 
                                    @"UTF-8", @"webkitTextEncoding", nil]];
+
     [env addEntriesFromDictionary:[defaults persistentDomainForName:myDomain]];
     
+    // This overrides hlTheme if hlThumbTheme is set and we're generating a thumbnail
+    // (This way we won't irritate people with existing installs)
+    // Admittedly, it's a little shady, overriding the set value, but I'd rather complicate the compiled code
+    if (thumbnail && [[env allKeys] containsObject:@"hlThumbTheme"]) {
+        [env setObject:[env objectForKey:@"hlThumbTheme"] forKey:@"hlTheme"];
+    }
+
     NSString *cmd = [NSString stringWithFormat:
                      @"'%@/colorize.sh' '%@' '%@' %s",
                      rsrcEsc, rsrcEsc, [targetEsc stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"], thumbnail ? "1" : "0"];


### PR DESCRIPTION
Overrides the theme setting if (and only if) hlThumbTheme is set and a thumbnail is to be generated. Does not interfere with default behavior/existing installations.