### PR TITLE
README.md: to install, suggest ~/Library instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This is a Quick Look plugin that renders source code with syntax highlighting,
 using the [Highlight library](http://www.andre-simon.de).
 
-To install the plugin, just drag it to `/Library/QuickLook`.
+To install the plugin, just drag it to `~/Library/QuickLook`.
 You may need to create that folder if it doesn't already exist.
 
 ## Settings


### PR DESCRIPTION
`~/Library/QuickLook` is the recommended directory for user installs. It does not require special permissions and any user can install on their own account without interfering with others (I’ve had quicklook plugins interfere with normal quicklook usage).