### PR TITLE
Remove bash_ref_linuxmanpages_com plugin

### DIFF
--- a/src/colorize.sh
+++ b/src/colorize.sh
@@ -103,7 +103,7 @@ case ${target} in
         ;;
     *.sh | *.zsh | *.bash | *.csh | *.fish | *.bashrc | *.zshrc )
         lang=sh
-        plugin=(--plug-in bash_functions --plug-in bash_ref_linuxmanpages_com)
+        plugin=(--plug-in bash_functions)
         ;;
     *.scala )
         lang=scala


### PR DESCRIPTION
This removes the `bash_ref_linuxmanpages_com` plugins as it has been removed from `highlight` in the latest release.

https://sourceforge.net/p/syntaxhighlight/code/167

Fixes QuickLook generation for shell files.

```
highlight: cannot open plugins/bash_ref_linuxmanpages_com.lua: No such file or directory in plugins/bash_ref_linuxmanpages_com.lua
```