### PR TITLE
fix: sql syntax highlighting

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -27,6 +27,7 @@
 				<string>public.tex</string>
 				<string>public.text</string>
 				<string>public.json</string>
+				<string>dyn.ah62d4rv4ge81g6pq</string>
 			</array>
 		</dict>
 	</array>
@@ -261,6 +262,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.source-code</string>
+				<string>dyn.ah62d4rv4ge81g6pq</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>SQL Source File</string>


### PR DESCRIPTION
For some interesting reasons macOS returns `dyn.ah62d4rv4ge81g6pq` as the sql UTI type:

```shell
$ mdls -name kMDItemContentType ~/test.sql
kMDItemContentType = "dyn.ah62d4rv4ge81g6pq"
```

This PR adds this strange UTI type to the list of supported files and to the sql extension.