### PR TITLE
Add option to preview file as RTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Here are some useful 'highlight' command-line flags (from the man page):
 
     defaults write org.n8gray.QLColorCode pathHL /path/to/your/highlight
 
+It is also possible to have the HTML preview converted to RTF.  Using RTF
+allows the contents of the file to be displayed instead of an icon -- similar
+to QLStephen.
+
+    defaults write org.n8gray.QLColorCode rtfRender true
+
 ## Additional information
 
 ### Additional features

--- a/src/Common.m
+++ b/src/Common.m
@@ -4,7 +4,7 @@
  *
  *  Created by Nathaniel Gray on 12/6/07.
  *  Copyright 2007 Nathaniel Gray.
- *  
+ *
  *  Modified by Anthony Gelibert on 9/5/12.
  *  Copyright 2012 Anthony Gelibert.
  */
@@ -23,28 +23,28 @@ NSData *runTask(NSString *script, NSDictionary *env, int *exitCode) {
     [task setEnvironment:env];
     [task setLaunchPath:@"/bin/sh"];
     [task setArguments:[NSArray arrayWithObjects:@"-c", script, nil]];
-    
+
     NSPipe *pipe;
     pipe = [NSPipe pipe];
     [task setStandardOutput: pipe];
     // Let stderr go to the usual place
     //[task setStandardError: pipe];
-    
+
     NSFileHandle *file;
     file = [pipe fileHandleForReading];
-    
+
     [task launch];
-    
+
     NSData *data;
     data = [file readDataToEndOfFile];
     [task waitUntilExit];
-    
+
     *exitCode = [task terminationStatus];
     [task release];
     /* The docs claim this isn't needed, but we leak descriptors otherwise */
     [file closeFile];
     /*[pipe release];*/
-    
+
     return data;
 }
 
@@ -66,17 +66,17 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
     n8log(@"url = %@", url);
     NSString *targetEsc = pathOfURL(url);
     n8log(@"targetEsc = %@", targetEsc);
-    
+
     // Set up preferences
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    
+
     NSMutableDictionary *env = [NSMutableDictionary dictionaryWithDictionary:
                                 [[NSProcessInfo processInfo] environment]];
 
     NSString *path = [env objectForKey: @"PATH"];
     NSString *newPath = [path stringByAppendingString: @":/usr/local/bin:/usr/local/sbin"];
     [env setObject: newPath forKey: @"PATH"];
-    
+
     // Try to find highlight location
     NSString *highlightPath = [[defaults persistentDomainForName:myDomain] valueForKey:@"pathHL"];
     if (highlightPath == nil) {
@@ -91,7 +91,7 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
         }
         [userDefaults release];
     }
-    
+
     [env addEntriesFromDictionary:[NSDictionary dictionaryWithObjectsAndKeys:
 #ifdef DEBUG
                                    @"1", @"qlcc_debug",
@@ -99,15 +99,15 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
                                    @"10", @"fontSizePoints",
                                    @"Menlo", @"font",
                                    @"edit-xcode", @"hlTheme",
-//                                   @"-lz -j 3 -t 4 --kw-case=capitalize ", @"extraHLFlags", 
-                                   @"-t 4 --kw-case=capitalize ", @"extraHLFlags", 
+//                                   @"-lz -j 3 -t 4 --kw-case=capitalize ", @"extraHLFlags",
+                                   @"-t 4 --kw-case=capitalize ", @"extraHLFlags",
                                    @"/opt/local/bin/highlight", @"pathHL",
                                    @"", @"maxFileSize",
-                                   @"UTF-8", @"textEncoding", 
+                                   @"UTF-8", @"textEncoding",
                                    @"UTF-8", @"webkitTextEncoding", nil]];
 
     [env addEntriesFromDictionary:[defaults persistentDomainForName:myDomain]];
-    
+
     // This overrides hlTheme if hlThumbTheme is set and we're generating a thumbnail
     // (This way we won't irritate people with existing installs)
     // Admittedly, it's a little shady, overriding the set value, but I'd rather complicate the compiled code
@@ -119,10 +119,10 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
                      @"'%@/colorize.sh' '%@' '%@' %s",
                      rsrcEsc, rsrcEsc, [targetEsc stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"], thumbnail ? "1" : "0"];
     n8log(@"cmd = %@", cmd);
-    
+
     output = runTask(cmd, env, status);
     if (*status != 0) {
-        NSLog(@"QLColorCode: colorize.sh failed with exit code %d.  Command was (%@).", 
+        NSLog(@"QLColorCode: colorize.sh failed with exit code %d.  Command was (%@).",
               *status, cmd);
     }
     return output;

--- a/src/GeneratePreviewForURL.m
+++ b/src/GeneratePreviewForURL.m
@@ -1,4 +1,4 @@
-/* This code is copyright Nathaniel Gray, licensed under the GPL v3.  
+/* This code is copyright Nathaniel Gray, licensed under the GPL v3.
     See LICENSE.txt for details. */
 
 #import <CoreFoundation/CoreFoundation.h>
@@ -10,12 +10,12 @@
 
 /* -----------------------------------------------------------------------------
  Generate a preview for file
- 
+
  This function's job is to create preview for designated file
  ----------------------------------------------------------------------------- */
 
-OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview, 
-                               CFURLRef url, CFStringRef contentTypeUTI, 
+OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
+                               CFURLRef url, CFStringRef contentTypeUTI,
                                CFDictionaryRef options)
 {
 #ifdef DEBUG
@@ -24,34 +24,34 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
     n8log(@"Generating Preview");
     if (QLPreviewRequestIsCancelled(preview))
         return noErr;
-    
+
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    
+
     // Invoke colorize.sh
     CFBundleRef bundle = QLPreviewRequestGetGeneratorBundle(preview);
     int status;
     NSData *output = colorizeURL(bundle, url, &status, 0);
-    n8log(@"Generated preview html page in %.3f sec", 
+    n8log(@"Generated preview html page in %.3f sec",
           -[startDate timeIntervalSinceNow] );
-    
+
     if (status != 0 || QLPreviewRequestIsCancelled(preview)) {
 #ifndef DEBUG
         goto done;
 #endif
     }
     // Now let WebKit do its thing
-    NSString *textEncoding = [[NSUserDefaults standardUserDefaults] 
+    NSString *textEncoding = [[NSUserDefaults standardUserDefaults]
                               stringForKey:@"webkitTextEncoding"];
     if (!textEncoding || [textEncoding length] == 0)
-        textEncoding = @"UTF-8";                
-    CFDictionaryRef properties = 
-            (CFDictionaryRef)[NSDictionary dictionaryWithObject:textEncoding 
+        textEncoding = @"UTF-8";
+    CFDictionaryRef properties =
+            (CFDictionaryRef)[NSDictionary dictionaryWithObject:textEncoding
                                                          forKey:(NSString *)kQLPreviewPropertyTextEncodingNameKey];
-    QLPreviewRequestSetDataRepresentation(preview, (CFDataRef)output, 
+    QLPreviewRequestSetDataRepresentation(preview, (CFDataRef)output,
                                           //kUTTypePlainText,
-                                          kUTTypeHTML, 
+                                          kUTTypeHTML,
                                           properties);
-    
+
 #ifndef DEBUG
 done:
 #endif

--- a/src/GenerateThumbnailForURL.m
+++ b/src/GenerateThumbnailForURL.m
@@ -14,12 +14,12 @@
    This function's job is to create thumbnail for designated file as fast as possible
    ----------------------------------------------------------------------------- */
 
-OSStatus 
-GenerateThumbnailForURL(void *thisInterface, 
-                                 QLThumbnailRequestRef thumbnail, 
-                                 CFURLRef url, 
-                                 CFStringRef contentTypeUTI, 
-                                 CFDictionaryRef options, 
+OSStatus
+GenerateThumbnailForURL(void *thisInterface,
+                                 QLThumbnailRequestRef thumbnail,
+                                 CFURLRef url,
+                                 CFStringRef contentTypeUTI,
+                                 CFDictionaryRef options,
                                  CGSize maxSize)
 {
     n8log(@"Generating Thumbnail");
@@ -31,16 +31,16 @@ GenerateThumbnailForURL(void *thisInterface,
 #ifdef DEBUG
     NSDate *startDate = [NSDate date];
 #endif
-    
-    // Render as though there is an 600x800 window, and fill the thumbnail 
+
+    // Render as though there is an 600x800 window, and fill the thumbnail
     // vertically.  This code could be more general.  I'm assuming maxSize is
     // a square, though nothing horrible should happen if it isn't.
-    
+
     NSRect renderRect = NSMakeRect(0.0, 0.0, 600.0, 800.0);
     float scale = (float)(maxSize.height/800.0);
     NSSize scaleSize = NSMakeSize(scale, scale);
     CGSize thumbSize = NSSizeToCGSize(
-                            NSMakeSize((maxSize.width * (600.0/800.0)), 
+                            NSMakeSize((maxSize.width * (600.0/800.0)),
                                        maxSize.height));
 
     /* Based on example code from quicklook-dev mailing list */
@@ -63,33 +63,33 @@ GenerateThumbnailForURL(void *thisInterface,
     WebView* webView = [[WebView alloc] initWithFrame:renderRect];
     [webView scaleUnitSquareToSize:scaleSize];
     [[[webView mainFrame] frameView] setAllowsScrolling:NO];
-    
+
     [[webView mainFrame] loadData:data MIMEType:@"text/html"
                  textEncodingName:@"UTF-8" baseURL:nil];
-    
+
     while([webView isLoading]) {
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
     }
-    
+
     // Get a context to render into
-    CGContextRef context = 
+    CGContextRef context =
         QLThumbnailRequestCreateContext(thumbnail, thumbSize, false, NULL);
-    
+
     if(context != NULL) {
-        NSGraphicsContext* nsContext = 
+        NSGraphicsContext* nsContext =
                     [NSGraphicsContext
-                        graphicsContextWithGraphicsPort:(void *)context 
+                        graphicsContextWithGraphicsPort:(void *)context
                                                 flipped:[webView isFlipped]];
-        
+
         [webView displayRectIgnoringOpacity:[webView bounds]
                                   inContext:nsContext];
-        
+
         QLThumbnailRequestFlushContext(thumbnail, context);
-        
+
         CFRelease(context);
     }
     [webView release];
-    
+
 #ifndef DEBUG
 done:
 #endif
@@ -100,7 +100,7 @@ done:
     return noErr;
 }
 
-void CancelThumbnailGeneration(void* thisInterface, 
+void CancelThumbnailGeneration(void* thisInterface,
                                QLThumbnailRequestRef thumbnail)
 {
     // implement only if supported


### PR DESCRIPTION
The first of these two commits removes trailing whitespace from the source files.

The second commit adds optional RTF rendering to the preview.  This has the effect of showing the contents of the file in the side panel of Finder instead of the customary icon; this behaviour is similar to QLStephen.  The only disadvantage of using RTF is that function folding is not available any more.