### PR TITLE
feat: Delete json support for quicklook-json

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -26,7 +26,6 @@
 				<string>org.vim.vim-script</string>
 				<string>public.tex</string>
 				<string>public.text</string>
-				<string>public.json</string>
 				<string>dyn.ah62d4rv4ge81g6pq</string>
 			</array>
 		</dict>


### PR DESCRIPTION
why: It is conflicted with quicklook-json
oth: We may have a option to activate or deactivate qlcolorcode for some
     file types

see: http://www.sagtau.com/quicklookjson.html