### PR TITLE
Add MacPort's default path to search PATH

### DIFF
--- a/src/Common.m
+++ b/src/Common.m
@@ -74,7 +74,7 @@ NSData *colorizeURL(CFBundleRef bundle, CFURLRef url, int *status, int thumbnail
                                 [[NSProcessInfo processInfo] environment]];
 
     NSString *path = [env objectForKey: @"PATH"];
-    NSString *newPath = [path stringByAppendingString: @":/usr/local/bin:/usr/local/sbin"];
+    NSString *newPath = [path stringByAppendingString: @":/opt/local/bin:/usr/local/bin:/usr/local/sbin"];
     [env setObject: newPath forKey: @"PATH"];
 
     // Try to find highlight location


### PR DESCRIPTION
The default highlight installed by MacPorts at `/opt/local/bin` didn't seem to be picked up by QLColorCode, so I added it to `PATH`.