### PR TITLE
Feature: Add support for Crystal language

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,7 @@
 				<string>dyn.ah62d4rv4ge80g62</string>
 				<string>dyn.ah62d4rv4ge80w5pq</string>
 				<string>dyn.ah62d4rv4ge80s52</string>
+				<string>dyn.ah62d4rv4ge80g6u</string>				
 			</array>
 		</dict>
 	</array>
@@ -1097,6 +1098,23 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>iml</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>dyn.ah62d4rv4ge80g6u</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Crystal Source File</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.crystal-lang.source</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>cr</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Added support for the Crystal language (see also https://crystal-lang.org). It should be noted that the README description for adding a new language does **NOT** work. I had to run ```qlmanage -d 4 -p hello.cr``` to determine the appropriate UTTypeIdentifier. 
Using ```mdls -name kMDItemContentType hello.cr``` returns ```public.crystal-source```as Universal Type Identifier (UTI). However, that value does not work when updating the Info.plist for the Crystal language.
 
BTW, this extension requires a corresponding change to the **highlight** library. I had to create a Crystal language definition file (```crystal.lang```) and update also the ```filetypes.conf``` file used by highlight in order to match a new language definition with the corresponding file extension. I will create a pull request for highlight so that these changes are reflected in a new highlight release.