### PR TITLE
Fix include path order and update readme

### DIFF
--- a/QLColorCode.xcodeproj/project.pbxproj
+++ b/QLColorCode.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 /* Begin PBXLegacyTarget section */
 		26BAC9AB257CE89900486D28 /* highlight */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "-j9 cli LUA_LIBS=../../lua/liblua.a 'CXX_COMPILE=clang++ -Wall -O2 -std=c++11 -D_FILE_OFFSET_BITS=64 -c -I /opt/local/include -I /usr/local/include -I ./include -I ../../lua'";
+			buildArgumentsString = "-j9 cli LUA_LIBS=../../lua/liblua.a 'CXX_COMPILE=clang++ -Wall -O2 -std=c++11 -D_FILE_OFFSET_BITS=64 -c -I ../../lua -I /opt/local/include -I /usr/local/include -I ./include'";
 			buildConfigurationList = 26BAC9AC257CE89900486D28 /* Build configuration list for PBXLegacyTarget "highlight" */;
 			buildPhases = (
 			);

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Alternatively, if you use [Homebrew Cask](https://github.com/caskroom/homebrew-c
 
 **To build the project, you must have Boost headers on your system in `/opt/local/include` or `/usr/local/include`.**
 
-Note that the build may fail if you have a version of `liblua.a` in a library
-path such as `/usr/local/lib`. In that case, temporarily uninstall Lua using
-the appropriate package manager.
-
 ## Settings
 
 If you want to configure `QLColorCode`, there are several `defaults` commands that could be useful:


### PR DESCRIPTION
This resolves the issue where a previously installed Lua may conflict with the one being used for Highlight. README no longer needs the notice.

https://github.com/macports/macports-ports/pull/9138#issuecomment-766342368